### PR TITLE
feat(proto): add bitrate.proto defining BitrateService API

### DIFF
--- a/service/proto/bitrate.proto
+++ b/service/proto/bitrate.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package bitrate;
+
+service BitrateService {
+  // Embedding step
+  rpc Prefill (Throughput) returns (Embedding);
+  // Final bitrate prediction
+  rpc Decode (Embedding) returns (Bitrate);
+}
+
+message Throughput {
+  double kbps = 1;
+}
+
+message Embedding {
+  repeated float values = 1;
+}
+
+message Bitrate {
+  double kbps = 1;
+}
+
+


### PR DESCRIPTION
- Create `proto/bitrate.proto` with:
  - `service BitrateService` exposing `Prefill(Throughput) → Embedding` and `Decode(Embedding) → Bitrate`
  - Message definitions:
    - `Throughput { double kbps = 1; }`
    - `Embedding { repeated float values = 1; }`
    - `Bitrate { double kbps = 1; }`
- Ensure all definitions compile without errors
